### PR TITLE
Replaced soap calls __call (deprecated) by __soapCall; Added loginAddDevice in apiFunctions.php

### DIFF
--- a/php/src/API/AuthenticationService.php
+++ b/php/src/API/AuthenticationService.php
@@ -104,7 +104,7 @@ class AuthenticationService extends \SoapClient {
    * @return authenticateResponse
    */
   public function authenticate(authenticate $parameters) {
-    return $this->__call('authenticate', array(
+    return $this->__soapCall('authenticate', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -121,7 +121,7 @@ class AuthenticationService extends \SoapClient {
    * @return authenticateWithIpResponse
    */
   public function authenticateWithIp(authenticateWithIp $parameters) {
-    return $this->__call('authenticateWithIp', array(
+    return $this->__soapCall('authenticateWithIp', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -138,7 +138,7 @@ class AuthenticationService extends \SoapClient {
    * @return authenticateRadiusResponse
    */
   public function authenticateRadius(authenticateRadius $parameters) {
-    return $this->__call('authenticateRadius', array(
+    return $this->__soapCall('authenticateRadius', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -155,7 +155,7 @@ class AuthenticationService extends \SoapClient {
    * @return authenticateExtendedResponse
    */
   public function authenticateExtended(authenticateExtended $parameters) {
-    return $this->__call('authenticateExtended', array(
+    return $this->__soapCall('authenticateExtended', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -172,7 +172,7 @@ class AuthenticationService extends \SoapClient {
    * @return sealVerifyResponse
    */
   public function sealVerify(sealVerify $parameters) {
-    return $this->__call('sealVerify', array(
+    return $this->__soapCall('sealVerify', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -189,7 +189,7 @@ class AuthenticationService extends \SoapClient {
    * @return sealDeferredVerifyResponse
    */
   public function sealDeferredVerify(sealDeferredVerify $parameters) {
-    return $this->__call('sealDeferredVerify', array(
+    return $this->__soapCall('sealDeferredVerify', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -206,7 +206,7 @@ class AuthenticationService extends \SoapClient {
    * @return pushAuthenticateResponse
    */
   public function pushAuthenticate(pushAuthenticate $parameters) {
-    return $this->__call('pushAuthenticate', array(
+    return $this->__soapCall('pushAuthenticate', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -223,7 +223,7 @@ class AuthenticationService extends \SoapClient {
    * @return checkPushResultResponse
    */
   public function checkPushResult(checkPushResult $parameters) {
-    return $this->__call('checkPushResult', array(
+    return $this->__soapCall('checkPushResult', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(

--- a/php/src/API/ConsoleAdminService.php
+++ b/php/src/API/ConsoleAdminService.php
@@ -252,7 +252,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginsQueryResponse
    */
   public function loginsQuery(loginsQuery $parameters) {
-    return $this->__call('loginsQuery', array(
+    return $this->__soapCall('loginsQuery', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -269,7 +269,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginSearchResponse
    */
   public function loginSearch(loginSearch $parameters) {
-    return $this->__call('loginSearch', array(
+    return $this->__soapCall('loginSearch', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -286,7 +286,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginQueryResponse
    */
   public function loginQuery(loginQuery $parameters) {
-    return $this->__call('loginQuery', array(
+    return $this->__soapCall('loginQuery', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -303,7 +303,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginCreateResponse
    */
   public function loginCreate(loginCreate $parameters) {
-    return $this->__call('loginCreate', array(
+    return $this->__soapCall('loginCreate', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -320,7 +320,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginUpdateResponse
    */
   public function loginUpdate(loginUpdate $parameters) {
-    return $this->__call('loginUpdate', array(
+    return $this->__soapCall('loginUpdate', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -337,7 +337,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginRestoreResponse
    */
   public function loginRestore(loginRestore $parameters) {
-    return $this->__call('loginRestore', array(
+    return $this->__soapCall('loginRestore', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -354,7 +354,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginResetPwdResponse
    */
   public function loginResetPwd(loginResetPwd $parameters) {
-    return $this->__call('loginResetPwd', array(
+    return $this->__soapCall('loginResetPwd', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -371,7 +371,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginAddDeviceResponse
    */
   public function loginAddDevice(loginAddDevice $parameters) {
-    return $this->__call('loginAddDevice', array(
+    return $this->__soapCall('loginAddDevice', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -388,7 +388,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginDeleteToolResponse
    */
   public function loginDeleteTool(loginDeleteTool $parameters) {
-    return $this->__call('loginDeleteTool', array(
+    return $this->__soapCall('loginDeleteTool', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -405,7 +405,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginDeleteResponse
    */
   public function loginDelete(loginDelete $parameters) {
-    return $this->__call('loginDelete', array(
+    return $this->__soapCall('loginDelete', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -422,7 +422,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginSendByMailResponse
    */
   public function loginSendByMail(loginSendByMail $parameters) {
-    return $this->__call('loginSendByMail', array(
+    return $this->__soapCall('loginSendByMail', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -439,7 +439,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return IWDS_checkResponse
    */
   public function IWDS_check(IWDS_check $parameters) {
-    return $this->__call('IWDS_check', array(
+    return $this->__soapCall('IWDS_check', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -456,7 +456,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginGetGroupsResponse
    */
   public function loginGetGroups(loginGetGroups $parameters) {
-    return $this->__call('loginGetGroups', array(
+    return $this->__soapCall('loginGetGroups', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -473,7 +473,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginsQueryByGroupResponse
    */
   public function loginsQueryByGroup(loginsQueryByGroup $parameters) {
-    return $this->__call('loginsQueryByGroup', array(
+    return $this->__soapCall('loginsQueryByGroup', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -490,7 +490,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginResetPwdExtendedResponse
    */
   public function loginResetPwdExtended(loginResetPwdExtended $parameters) {
-    return $this->__call('loginResetPwdExtended', array(
+    return $this->__soapCall('loginResetPwdExtended', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -507,7 +507,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginGetInfoFromLinkResponse
    */
   public function loginGetInfoFromLink(loginGetInfoFromLink $parameters) {
-    return $this->__call('loginGetInfoFromLink', array(
+    return $this->__soapCall('loginGetInfoFromLink', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -524,7 +524,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginGetCodeFromLinkResponse
    */
   public function loginGetCodeFromLink(loginGetCodeFromLink $parameters) {
-    return $this->__call('loginGetCodeFromLink', array(
+    return $this->__soapCall('loginGetCodeFromLink', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -541,7 +541,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginActivateCodeResponse
    */
   public function loginActivateCode(loginActivateCode $parameters) {
-    return $this->__call('loginActivateCode', array(
+    return $this->__soapCall('loginActivateCode', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -558,7 +558,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return loginResetPINErrorCounterResponse
    */
   public function loginResetPINErrorCounter(loginResetPINErrorCounter $parameters) {
-    return $this->__call('loginResetPINErrorCounter', array(
+    return $this->__soapCall('loginResetPINErrorCounter', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -575,7 +575,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return serviceGroupsQueryResponse
    */
   public function serviceGroupsQuery(serviceGroupsQuery $parameters) {
-    return $this->__call('serviceGroupsQuery', array(
+    return $this->__soapCall('serviceGroupsQuery', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -592,7 +592,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return groupAccountQueryResponse
    */
   public function groupAccountQuery(groupAccountQuery $parameters) {
-    return $this->__call('groupAccountQuery', array(
+    return $this->__soapCall('groupAccountQuery', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -609,7 +609,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return groupAccountCreateResponse
    */
   public function groupAccountCreate(groupAccountCreate $parameters) {
-    return $this->__call('groupAccountCreate', array(
+    return $this->__soapCall('groupAccountCreate', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -626,7 +626,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return groupAccountUpdateResponse
    */
   public function groupAccountUpdate(groupAccountUpdate $parameters) {
-    return $this->__call('groupAccountUpdate', array(
+    return $this->__soapCall('groupAccountUpdate', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(
@@ -643,7 +643,7 @@ class ConsoleAdminService extends \SoapClient {
    * @return groupAccountDeleteResponse
    */
   public function groupAccountDelete(groupAccountDelete $parameters) {
-    return $this->__call('groupAccountDelete', array(
+    return $this->__soapCall('groupAccountDelete', array(
             new \SoapParam($parameters, 'parameters')
       ),
       array(

--- a/php/src/resources/apiFunctions.php
+++ b/php/src/resources/apiFunctions.php
@@ -338,6 +338,28 @@ class apiFunctions {
         $this->printError($res);
         return $res;
     }
+
+	// Add a device for a user by its login ID, with codetype
+    public function loginAddDevice($loginId, $codetype) {
+        
+        try { 
+            $x = new API\loginAddDevice;
+            $x->userid = $this->uid;
+            $x->serviceid = $this->serviceId;
+			$x->loginid = $loginId;
+			$x->codetype = $codetype;
+			
+            
+            $resp = $this->provisioning->loginAddDevice($x);
+            $res = $resp->loginAddDeviceReturn;
+        
+        } catch (\Exception $error) {   
+            $this->printError($error);
+            return "NOK";
+        }
+		$this->printError($res);        
+        return $res;
+    }
     
     /* USER SEARCH */
     


### PR DESCRIPTION
Soap calls __call deprecated (see https://www.php.net/manual/en/soapclient.call.php). Not working on a brand new use
Added loginAddDevice in apiFunctions.php. More functions are missing. They will be added later